### PR TITLE
Fix Jupiter perp account decoding

### DIFF
--- a/backend/src/services/perp-connectors/__tests__/jupiter-idl.test.ts
+++ b/backend/src/services/perp-connectors/__tests__/jupiter-idl.test.ts
@@ -1,0 +1,11 @@
+import { createJupiterAccountsCoder } from '../jupiter';
+
+describe('Jupiter IDL coder', () => {
+  it('exposes camelCase account layouts for pool and custody', () => {
+    const coder = createJupiterAccountsCoder() as unknown as { accountLayouts: Map<string, unknown> };
+    const accountNames = Array.from(coder.accountLayouts.keys());
+
+    expect(accountNames).toContain('pool');
+    expect(accountNames).toContain('custody');
+  });
+});


### PR DESCRIPTION
## Summary
- normalize IDL defined types using camelCase conversion and expose a helper to build the Jupiter accounts coder
- decode Jupiter pool and custody accounts with the correct camelCase names expected by the IDL
- add a unit test ensuring the coder exposes the pool and custody account layouts

## Testing
- npm test -- --runTestsByPath src/services/perp-connectors/__tests__/jupiter-idl.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7c41d2c608333b5cd76de027bd091