### PR TITLE
Honor live mode for perp connectors

### DIFF
--- a/backend/src/routes/__tests__/perp-connectors.test.ts
+++ b/backend/src/routes/__tests__/perp-connectors.test.ts
@@ -61,7 +61,11 @@ describe('Perp Connectors Route', () => {
     expect(Array.isArray(response.body.connectors)).toBe(true);
     expect(Array.isArray(response.body.summary)).toBe(true);
     expect(response.body.connectors.length).toBeGreaterThan(0);
-    expect(mockedFetchAllPerpMarkets).toHaveBeenCalledWith({ useMockData: true });
+    expect(mockedFetchAllPerpMarkets).toHaveBeenCalledWith({
+      useMockData: true,
+      preferLive: false,
+      mode: 'mock',
+    });
     expect(mockedListPerpConnectors).toHaveBeenCalled();
   });
 
@@ -85,6 +89,32 @@ describe('Perp Connectors Route', () => {
     expect(response.status).toBe(200);
     expect(response.body.mode).toBe('auto');
     expect(Array.isArray(response.body.summary)).toBe(true);
-    expect(mockedFetchAllPerpMarkets).toHaveBeenCalledWith(undefined);
+    expect(mockedFetchAllPerpMarkets).toHaveBeenCalledWith({ mode: 'auto', preferLive: false });
+  });
+
+  it('should request live mode with preferLive flag enabled', async () => {
+    mockedFetchAllPerpMarkets.mockResolvedValueOnce([
+      {
+        meta: {
+          id: 'avantis',
+          name: 'Avantis',
+          description: 'Test connector',
+          requiresApiKey: false,
+        },
+        markets: [],
+        lastUpdated: '2025-01-01T00:00:00Z',
+        source: 'mock',
+      },
+    ]);
+
+    const response = await request(app).get('/perp-connectors?mode=live');
+
+    expect(response.status).toBe(200);
+    expect(response.body.mode).toBe('live');
+    expect(mockedFetchAllPerpMarkets).toHaveBeenCalledWith({
+      useMockData: false,
+      preferLive: true,
+      mode: 'live',
+    });
   });
 });

--- a/backend/src/routes/perp-connectors.ts
+++ b/backend/src/routes/perp-connectors.ts
@@ -9,9 +9,11 @@ router.get('/', async (req: Request, res: Response) => {
 
   let ctx: PerpConnectorContext | undefined;
   if (modeParam === 'mock') {
-    ctx = { useMockData: true };
+    ctx = { useMockData: true, preferLive: false, mode: 'mock' };
   } else if (modeParam === 'live') {
-    ctx = { useMockData: false };
+    ctx = { useMockData: false, preferLive: true, mode: 'live' };
+  } else {
+    ctx = { mode: 'auto', preferLive: false };
   }
 
   try {

--- a/backend/src/services/perp-connectors/__tests__/avantis.spec.ts
+++ b/backend/src/services/perp-connectors/__tests__/avantis.spec.ts
@@ -183,4 +183,15 @@ describe('avantisConnector.fetchMarkets', () => {
       'Failed to fetch Avantis markets: network down',
     );
   });
+
+  it('rethrows the live error when preferLive is requested', async () => {
+    mockedAxiosGet.mockRejectedValueOnce(new Error('network down'));
+
+    await expect(
+      avantisConnector.fetchMarkets({ useMockData: false, preferLive: true }),
+    ).rejects.toThrow('network down');
+
+    expect(mockedGetMockMarkets).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
 });

--- a/backend/src/services/perp-connectors/__tests__/jupiter-idl.test.ts
+++ b/backend/src/services/perp-connectors/__tests__/jupiter-idl.test.ts
@@ -1,0 +1,71 @@
+// Tests for Jupiter connector helpers.
+
+jest.mock('node-fetch', () => {
+  const mockFetch = jest.fn(() => Promise.resolve({ ok: true })) as jest.Mock;
+  return { __esModule: true, default: mockFetch };
+});
+
+describe('Jupiter IDL coder', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('exposes camelCase account layouts for pool and custody', async () => {
+    const { createJupiterAccountsCoder } = await import('../jupiter');
+    const coder = createJupiterAccountsCoder() as unknown as { accountLayouts: Map<string, unknown> };
+
+    const accountNames = Array.from(coder.accountLayouts.keys());
+
+    expect(accountNames).toContain('pool');
+    expect(accountNames).toContain('custody');
+  });
+});
+
+describe('createJupiterRpcFetch', () => {
+  const resetEnv = () => {
+    delete process.env.JUPITER_SOLANA_RPC_PROXY;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.https_proxy;
+    delete process.env.HTTP_PROXY;
+    delete process.env.http_proxy;
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    resetEnv();
+  });
+
+  async function setup() {
+    const fetchModule = await import('node-fetch');
+    const mockedFetch = fetchModule.default as unknown as jest.Mock;
+    mockedFetch.mockReset();
+    mockedFetch.mockResolvedValue({ ok: true } as any);
+    const { createJupiterRpcFetch } = await import('../jupiter');
+    return { mockedFetch, createJupiterRpcFetch };
+  }
+
+  it('returns native fetch when no proxy is configured', async () => {
+    const { mockedFetch, createJupiterRpcFetch } = await setup();
+
+    const rpcFetch = createJupiterRpcFetch();
+    await rpcFetch('https://rpc.test', { method: 'POST' });
+
+    expect(mockedFetch).toHaveBeenCalledWith('https://rpc.test', { method: 'POST' });
+  });
+
+  it('attaches a proxy agent when a proxy environment variable is set', async () => {
+    process.env.HTTPS_PROXY = 'http://proxy:8080';
+    const { mockedFetch, createJupiterRpcFetch } = await setup();
+
+    const rpcFetch = createJupiterRpcFetch();
+    await rpcFetch('https://rpc.test');
+
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    const [, init] = mockedFetch.mock.calls[0];
+    expect(init).toBeDefined();
+    expect((init as any).agent).toBeDefined();
+    expect(((init as any).agent as { constructor: { name: string } }).constructor.name).toBe(
+      'JupiterHttpsProxyAgent',
+    );
+  });
+});

--- a/backend/src/services/perp-connectors/aster.ts
+++ b/backend/src/services/perp-connectors/aster.ts
@@ -167,6 +167,7 @@ const asterConnector: PerpConnector = {
   },
   async fetchMarkets(ctx?: PerpConnectorContext): Promise<PerpConnectorResult> {
     const useMock = ctx?.useMockData ?? false;
+    const preferLive = ctx?.preferLive ?? false;
 
     if (useMock) {
       const mock = getMockMarkets('aster');
@@ -181,6 +182,10 @@ const asterConnector: PerpConnector = {
     try {
       return await fetchLiveMarkets();
     } catch (error) {
+      if (preferLive) {
+        throw error instanceof Error ? error : new Error(String(error));
+      }
+      console.warn('[Perp][Aster] Falling back to mock data:', (error as Error).message);
       const mock = getMockMarkets('aster');
       return {
         meta: this.meta,

--- a/backend/src/services/perp-connectors/avantis.ts
+++ b/backend/src/services/perp-connectors/avantis.ts
@@ -207,6 +207,7 @@ const avantisConnector: PerpConnector = {
   },
   async fetchMarkets(ctx?: PerpConnectorContext): Promise<PerpConnectorResult> {
     const useMock = ctx?.useMockData ?? false;
+    const preferLive = ctx?.preferLive ?? false;
     if (useMock) {
       const mock = getMockMarkets('avantis');
       return {
@@ -220,6 +221,9 @@ const avantisConnector: PerpConnector = {
     try {
       return await fetchLiveMarkets();
     } catch (error) {
+      if (preferLive) {
+        throw error instanceof Error ? error : new Error(String(error));
+      }
       console.warn('[Perp][Avantis] Falling back to mock data:', (error as Error).message);
       const mock = getMockMarkets('avantis');
       return {

--- a/backend/src/services/perp-connectors/cache.ts
+++ b/backend/src/services/perp-connectors/cache.ts
@@ -11,7 +11,8 @@ const TTL_MOCK_MS = Number(process.env.PERP_CONNECTOR_MOCK_TTL_MS ?? 10_000);
 const cache = new Map<string, CacheEntry>();
 
 function getCacheKey(connectorId: string, ctx?: PerpConnectorContext): string {
-  const mode = ctx?.useMockData ? 'mock' : 'auto';
+  const mode =
+    ctx?.mode ?? (ctx?.useMockData ? 'mock' : ctx?.preferLive ? 'live' : 'auto');
   return `${connectorId}:${mode}`;
 }
 

--- a/backend/src/services/perp-connectors/index.ts
+++ b/backend/src/services/perp-connectors/index.ts
@@ -28,6 +28,11 @@ export async function fetchAllPerpMarkets(ctx?: PerpConnectorContext): Promise<P
       const result = await getConnectorResultWithCache(connector, ctx);
       results.push(result);
     } catch (error) {
+      if (ctx?.preferLive) {
+        throw new Error(
+          `Connector "${connector.meta.id}" failed to fetch live markets: ${(error as Error).message}`,
+        );
+      }
       results.push({
         meta: connector.meta,
         markets: [],

--- a/backend/src/services/perp-connectors/synfutures.ts
+++ b/backend/src/services/perp-connectors/synfutures.ts
@@ -31,6 +31,7 @@ const synfuturesConnector: PerpConnector = {
   },
   async fetchMarkets(ctx?: PerpConnectorContext): Promise<PerpConnectorResult> {
     const useMock = ctx?.useMockData ?? false;
+    const preferLive = ctx?.preferLive ?? false;
     if (useMock) {
       const mock = getMockMarkets('synfutures_v3');
       return {
@@ -44,6 +45,10 @@ const synfuturesConnector: PerpConnector = {
     try {
       return await fetchLiveMarkets();
     } catch (error) {
+      if (preferLive) {
+        throw error instanceof Error ? error : new Error(String(error));
+      }
+      console.warn('[Perp][SynFutures] Falling back to mock data:', (error as Error).message);
       const mock = getMockMarkets('synfutures_v3');
       return {
         meta: this.meta,

--- a/backend/src/types/perp.ts
+++ b/backend/src/types/perp.ts
@@ -28,8 +28,21 @@ export interface PerpConnectorMetadata {
   requiresApiKey: boolean;
 }
 
+export type PerpConnectorMode = 'auto' | 'mock' | 'live';
+
 export interface PerpConnectorContext {
   useMockData?: boolean;
+  /**
+   * When true the caller explicitly requested a live pull. In this mode
+   * connectors should surface the underlying error instead of silently
+   * falling back to mock data so the UI can surface the failure state.
+   */
+  preferLive?: boolean;
+  /**
+   * Provides the resolved mode so cache keys can differentiate between
+   * automatic, mock, and forced-live requests.
+   */
+  mode?: PerpConnectorMode;
 }
 
 export interface PerpConnectorResult {


### PR DESCRIPTION
## Summary
- add an explicit connector mode context so cache keys and callers can distinguish auto, mock, and forced-live requests
- surface forced-live requests through the REST router and shared aggregator so errors bubble up instead of silently returning mocks
- update the individual connectors to honour the preferLive flag and add coverage to ensure they throw instead of masking failures

## Testing
- npm test -- --runTestsByPath src/routes/__tests__/perp-connectors.test.ts src/services/perp-connectors/__tests__/avantis.spec.ts src/services/perp-connectors/__tests__/jupiter-idl.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7c41d2c608333b5cd76de027bd091