### PR TITLE
Revise Hyperliquid opportunity scoring for longer holds

### DIFF
--- a/frontend/app/hyperliquid/page.tsx
+++ b/frontend/app/hyperliquid/page.tsx
@@ -12,8 +12,8 @@ import type { HyperliquidOpportunityFilters, PerpConnectorMode } from './types';
 
 const DEFAULT_OPPORTUNITY_FILTERS: HyperliquidOpportunityFilters = {
   limit: 12,
-  minOpenInterestUsd: 500_000,
-  minVolumeUsd: 250_000,
+  minOpenInterestUsd: 3_000_000,
+  minVolumeUsd: 1_000_000,
   direction: 'short',
   sort: 'score',
   notionalUsd: 10_000,

--- a/frontend/app/hyperliquid/types.ts
+++ b/frontend/app/hyperliquid/types.ts
@@ -122,6 +122,10 @@ export interface HyperliquidOpportunity {
   opportunityScore: number;
   liquidityScore: number;
   volumeScore: number;
+  fundingStrength?: number;
+  stabilityAdjustment?: number;
+  feasibilityWeight?: number;
+  fundingRateStdDevAnnualized?: number;
   expectedDailyReturnPercent: number;
   estimatedDailyPnlUsd: number;
   estimatedMonthlyPnlUsd: number;
@@ -146,6 +150,7 @@ export interface HyperliquidOpportunityFilters {
   direction: OpportunityDirectionFilter;
   sort: OpportunitySort;
   notionalUsd: number;
+  tradingCostDaily?: number;
 }
 
 export interface HyperliquidOpportunityPayload {

--- a/frontend/lib/api-config.ts
+++ b/frontend/lib/api-config.ts
@@ -17,6 +17,7 @@ export const endpoints = {
     direction?: 'short' | 'long' | 'all';
     sort?: 'score' | 'funding' | 'liquidity' | 'volume';
     notionalUsd?: number;
+    tradingCostDaily?: number;
   } = {}) => {
     const searchParams = new URLSearchParams();
     Object.entries(params).forEach(([key, value]) => {


### PR DESCRIPTION
## Summary
- incorporate funding stability, feasibility weighting, and optional trading-cost buffers into Hyperliquid opportunity scoring
- raise default liquidity and volume thresholds and surface the new scoring metrics to the frontend

## Testing
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68e81b8061488333a1a8f12e4017f093