### PR TITLE
Blend opportunity and RANY metrics for Hyperliquid opportunities

### DIFF
--- a/frontend/app/hyperliquid/types.ts
+++ b/frontend/app/hyperliquid/types.ts
@@ -149,6 +149,7 @@ export interface HyperliquidOpportunity {
   marketHealthScore?: number;
   compositeRiskFactor?: number;
   ranyScore?: number;
+  combinedScore?: number;
 }
 
 export interface HyperliquidOpportunityTotals {


### PR DESCRIPTION
## Summary
- add a backend blended score that weights opportunity strength and RANY risk-adjusted yield for ranking
- propagate the blended score through the frontend hook and types so fallback data sorts the same way
- refresh the opportunity card UI to show the new blended indicator with context on the underlying metrics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8259fd0348333ab66a2ef1af60a97