### PR TITLE
Add guard-based pricing to Hyperliquid recommendation

### DIFF
--- a/backend/src/routes/__tests__/hyperliquid-guard.test.ts
+++ b/backend/src/routes/__tests__/hyperliquid-guard.test.ts
@@ -1,0 +1,43 @@
+import {
+  calculateGuardedLiquidationPrice,
+  getApplicableMarginTableLeverage,
+  setLatestMarginTables,
+  type HyperliquidMarginTable,
+} from '../hyperliquid';
+
+describe('hyperliquid guard helpers', () => {
+  beforeEach(() => {
+    setLatestMarginTables(null);
+  });
+
+  it('returns undefined leverage when no margin tables are cached', () => {
+    const leverage = getApplicableMarginTableLeverage(123, 1_000_000);
+    expect(leverage).toBeUndefined();
+  });
+
+  it('selects the correct tier for a notional size', () => {
+    const marginTable: HyperliquidMarginTable = {
+      description: 'tiered 10x',
+      marginTiers: [
+        { lowerBound: 0, maxLeverage: 10 },
+        { lowerBound: 3_000_000, maxLeverage: 5 },
+      ],
+    };
+
+    const tableMap = new Map<number, HyperliquidMarginTable>();
+    tableMap.set(51, marginTable);
+    setLatestMarginTables(tableMap);
+
+    expect(getApplicableMarginTableLeverage(51, 2_000_000)).toBe(10);
+    expect(getApplicableMarginTableLeverage(51, 4_000_000)).toBe(5);
+  });
+
+  it('computes guarded liquidation price when collateral covers a 100% move', () => {
+    const entryPrice = 100;
+    const positionSize = 10; // $1,000 notional
+    const collateral = 1_000; // Matches notional for 1× guard
+
+    const liquidationPrice = calculateGuardedLiquidationPrice(entryPrice, positionSize, collateral);
+    expect(liquidationPrice).toBeCloseTo(200, 6);
+  });
+});

--- a/frontend/app/hyperliquid/components/RecommendationSection.tsx
+++ b/frontend/app/hyperliquid/components/RecommendationSection.tsx
@@ -109,6 +109,25 @@ export function RecommendationSection({ walletAddress, filters }: Recommendation
     return formatNumber(value, 2);
   };
 
+  const formatPrice = (value: number | null | undefined) => {
+    if (value === null || value === undefined || !Number.isFinite(value)) {
+      return '—';
+    }
+    return formatCurrency(value);
+  };
+
+  const renderGuardMultiple = (value: number | null | undefined) => {
+    if (value === null || value === undefined || !Number.isFinite(value)) {
+      return null;
+    }
+
+    return (
+      <p className="text-xs text-emerald-600 dark:text-emerald-300 mt-0.5">
+        Guarded to {formatNumber(value, 2)}×
+      </p>
+    );
+  };
+
   return (
     <section className="rounded-2xl border border-slate-200/70 dark:border-slate-800/70 bg-white/80 dark:bg-slate-900/50 shadow-sm">
       <div className="p-6 border-b border-slate-200/60 dark:border-slate-800/60 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
@@ -310,6 +329,21 @@ l
                 <div>
                   <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">Expected Monthly PnL</p>
                   <p className="text-base font-semibold">{formatCurrency(recommendation.expectedMonthlyPnlUsd)}</p>
+                </div>
+              </div>
+              <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm text-slate-700 dark:text-slate-200">
+                <div>
+                  <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">Entry Price</p>
+                  <p className="text-base font-semibold">{formatPrice(recommendation.entryPrice ?? recommendation.markPrice)}</p>
+                </div>
+                <div>
+                  <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">Liquidation Price</p>
+                  <p className="text-base font-semibold">{formatPrice(recommendation.liquidationPrice)}</p>
+                </div>
+                <div>
+                  <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">Max Price Before Liquidation</p>
+                  <p className="text-base font-semibold">{formatPrice(recommendation.maxPriceBeforeLiquidation)}</p>
+                  {renderGuardMultiple(recommendation.guardMultiple)}
                 </div>
               </div>
             </div>

--- a/frontend/app/hyperliquid/types.ts
+++ b/frontend/app/hyperliquid/types.ts
@@ -206,7 +206,11 @@ export interface HyperliquidRecommendationSuggestion {
   positionSize: number;
   positionNotionalUsd: number;
   leverage: number;
+  entryPrice: number | null;
   markPrice: number;
+  liquidationPrice: number | null;
+  maxPriceBeforeLiquidation: number | null;
+  guardMultiple: number | null;
   combinedScore: number | null;
   opportunityScore: number;
   ranyScore: number | null;


### PR DESCRIPTION
## Summary
- cache Hyperliquid margin tables and cap recommended sizing to withstand a 100% adverse move
- expose entry, liquidation, and guard price details through the recommendation API and UI
- cover the new guard helpers with targeted Jest tests

## Testing
- npm test -- hyperliquid-guard

------
https://chatgpt.com/codex/tasks/task_e_68e8ece397c88333801a9ab1f5cd5edb